### PR TITLE
Bug Fix: LeaseDuration is currently mandatory #9

### DIFF
--- a/DSCResources/MSFT_xDhcpServerScope/MSFT_xDhcpServerScope.psm1
+++ b/DSCResources/MSFT_xDhcpServerScope/MSFT_xDhcpServerScope.psm1
@@ -176,7 +176,10 @@ function Test-TargetResource
     }
 
     # Convert the Lease duration to be a valid timespan
-    $LeaseDuration = (Get-ValidTimeSpan -tsString $LeaseDuration -parameterName 'Leaseduration').ToString()
+    if($LeaseDuration)
+    {
+        $LeaseDuration = (Get-ValidTimeSpan -tsString $LeaseDuration -parameterName 'Leaseduration').ToString()
+    }
     
 #endregion Input Validation
 

--- a/README.md
+++ b/README.md
@@ -54,11 +54,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 
-<<<<<<< HEAD
-* Bug Fix LeaseDuration is no longer mandatory for xDhcpServerScope resource.
-=======
 * Added **xDhcpServerAuthorization** resource.
->>>>>>> refs/remotes/PowerShell/dev
+* Bug Fix LeaseDuration is no longer mandatory for xDhcpServerScope resource.
 
 ### 1.2
 

--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ## Versions
 
+### Unreleased
+
+* Bug Fix LeaseDuration is no longer mandatory for xDhcpServerScope resource.
+
 ### 1.2
 
 * Fix "Cannot set default gateway on xDhcpServerOption".


### PR DESCRIPTION
Fixed bug causing Test-TargetResource to fail when LeaseDuration is not specified. 