### PR TITLE
Multiple Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+DSCResource.Tests

--- a/DSCResources/MSFT_xDhcpServerAuthorization/MSFT_xDhcpServerAuthorization.psm1
+++ b/DSCResources/MSFT_xDhcpServerAuthorization/MSFT_xDhcpServerAuthorization.psm1
@@ -5,8 +5,8 @@ data LocalizedData
 {
     # culture="en-US"
     ConvertFrom-StringData @'
-ResolvingIPv4Address      = Resolving local IPv4 IP addresses
-ResolvingHostname         = Resolving local hostname
+ResolvingIPv4Address      = Resolving first local IPv4 IP address ...
+ResolvingHostname         = Resolving local hostname ...
 AuthorizingServer         = Authorizing DHCP Server '{0}' with IP address '{1}'
 UnauthorizingServer       = Unauthorizing DHCP Server '{0}' with IP address '{1}'
 ServerIsAuthorized        = DHCP Server '{0}' with IP address '{1}' IS authorized
@@ -141,9 +141,8 @@ function Get-IPv4Address
     {
         Write-Verbose $LocalizedData.ResolvingIPv4Address
         Get-WmiObject Win32_NetworkAdapterConfiguration -Namespace 'root\CIMV2' |
-            Where IPEnabled -eq 'True' |
-                ForEach-Object
-                {
+            Where-Object IPEnabled -eq 'True' |
+                ForEach-Object {
                     Write-Output ($_.IPAddress -notmatch ':')
                 }
     } #end process

--- a/DSCResources/MSFT_xDhcpServerOption/MSFT_xDhcpServerOption.psm1
+++ b/DSCResources/MSFT_xDhcpServerOption/MSFT_xDhcpServerOption.psm1
@@ -259,7 +259,7 @@ function ValidateResourceProperties
                 $checkPropertyMessage = $($LocalizedData.CheckPropertyMessage) -f 'Dns server ip'
                 Write-Verbose -Message $checkPropertyMessage
                 
-                $dnsServerIP = ($dhcpOption | Where-Object Name -like 'DNS Servers').value
+                $dnsServerIP = ($DhcpOption | Where-Object OptionId -eq 6).Value
                 # If comparison return something, they are not equal
                 if((-not $dnsServerIP) -or (Compare-Object $dnsServerIP $DnsServerIPAddress))
                 {
@@ -294,7 +294,7 @@ function ValidateResourceProperties
                 $checkPropertyMessage = $($LocalizedData.CheckPropertyMessage) -f 'Dns domain name'
                 Write-Verbose -Message $checkPropertyMessage
 
-                $dnsDomainName = ($DhcpOption | Where-Object Name -like 'DNS Domain Name').value
+                $dnsDomainName = ($DhcpOption | Where-Object OptionId -eq 15).Value
                 if($dnsDomainName -ne $DnsDomain) 
                 {
                     $notDesiredPropertyMessage = $($LocalizedData.NotDesiredPropertyMessage) -f 'DNS domain name', $DnsDomain, ($dnsDomainName -join ', ')
@@ -329,7 +329,7 @@ function ValidateResourceProperties
                 $checkPropertyMessage = $($LocalizedData.CheckPropertyMessage) -f 'Router ip addresses'
                 Write-Verbose -Message $checkPropertyMessage
 
-                $routerIP = ($DhcpOption | Where-Object OptionId -eq 3).value
+                $routerIP = ($DhcpOption | Where-Object OptionId -eq 3).Value
 
                 if((-not $routerIP) -or (Compare-Object $routerIP $Router))
                 {

--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **Name**: Name of this DHCP Scope
 * **SubnetMask**: Subnet mask for the scope specified in IP address format
 * **LeaseDuration**: Time interval for which an IP address should be leased
- * This should be specified in the following format: `Days:Hours:Minutes:Seconds`
- * For example, '`02:00:00:00`' is 2 days and '`08:00:00`' is 8 hours.
+ * This should be specified in the following format: `Days.Hours:Minutes:Seconds`
+ * For example, '`02.00:00:00`' is 2 days and '`08:00:00`' is 8 hours.
 * **State**: Whether scope should be active or inactive.
 * **Ensure**: Whether DHCP scope should be present or removed
 * **ScopeID**: Scope Identifier. This is a read-only property for this resource.
@@ -55,6 +55,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ## Versions
 
 ### Unreleased
+
+* Bug Fix fixes localization bug in xDhcpServerScope option enumeration
 
 ### 1.3.0.0
 

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **Name**: Name of this DHCP Scope
 * **SubnetMask**: Subnet mask for the scope specified in IP address format
 * **LeaseDuration**: Time interval for which an IP address should be leased
+ * This should be specified in the following format: `Days:Hours:Minutes:Seconds`
+ * For example, '`02:00:00:00`' is 2 days and '`08:00:00`' is 8 hours.
 * **State**: Whether scope should be active or inactive.
 * **Ensure**: Whether DHCP scope should be present or removed
 * **ScopeID**: Scope Identifier. This is a read-only property for this resource.

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ configuration Sample_xDhcpsServerScope_NewScope
         IPStartRange = '192.168.1.1'
         Name = 'PowerShellScope'
         SubnetMask = '255.255.255.0'
-        LeaseDuration = '00:08:00'
+        LeaseDuration = ((New-TimeSpan -Hours 8 ).ToString())
         State = 'Active'
         AddressFamily = 'IPv4'
     }

--- a/Tests/Unit/MSFT_xDhcpServerScope.Tests.ps1
+++ b/Tests/Unit/MSFT_xDhcpServerScope.Tests.ps1
@@ -1,0 +1,258 @@
+$Global:DSCModuleName      = 'xDhcpServer'
+$Global:DSCResourceName    = 'MSFT_xDhcpServerScope'
+
+#region HEADER
+[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
+if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+else
+{
+    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
+}
+Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Unit 
+#endregion
+
+# Begin Testing
+try
+{
+    #region Pester Tests
+
+    # The InModuleScope command allows you to perform white-box unit testing on the internal
+    # (non-exported) code of a Script Module.
+    InModuleScope $Global:DSCResourceName {
+
+        #region Pester Test Initialization
+        # TODO: Optopnal Load Mock for use in Pester tests here...
+        #endregion
+
+        $testScopeName = 'Test Scope';
+        $testScopeID = '192.168.1.0';
+        $testIPStartRange = '192.168.1.10';
+        $testIPEndRange = '192.168.1.99';
+        $testSubnetMask = '255.255.255.0';
+        $testState = 'Active';
+        $testLeaseDuration = New-TimeSpan -Days 8;
+        
+        $testParams = @{
+            Name = $testScopeName;
+            IPStartRange = $testIPStartRange;
+            IPEndRange = $testIPEndRange;
+            SubnetMask = $testSubnetMask;
+        }
+                
+        $fakeDhcpServerv4Scope = [PSCustomObject] @{
+            ScopeID = $testScopeID;
+            Name = $testScopeName;
+            StartRange = $testIPStartRange;
+            EndRange = $testIPEndRange;
+            SubnetMask = $testSubnetMask;
+            LeaseDuration = $testLeaseDuration;
+            State = $testState;
+            AddressFamily = 'IPv4';
+        }
+
+        #region Function Get-TargetResource
+        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+
+            Mock Assert-Module -ParameterFilter { $ModuleName -eq 'DHCPServer' } { }
+
+            It 'Calls "Assert-Module" to ensure "DHCPServer" module is available' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                
+                $result = Get-TargetResource @testParams;
+                
+                Assert-MockCalled Assert-Module -ParameterFilter { $ModuleName -eq 'DHCPServer' } -Scope It;
+            }
+            
+            It 'Returns a "System.Collections.Hashtable" object type' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                $result = Get-TargetResource @testParams;
+                
+                $result -is [System.Collections.Hashtable] | Should Be $true;
+            }
+        }
+        #endregion Function Get-TargetResource
+
+        #region Function Test-TargetResource
+        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+            
+            Mock Assert-Module -ParameterFilter { $ModuleName -eq 'DHCPServer' } { }
+
+            It 'Returns a "System.Boolean" object type' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                
+                $result = Test-TargetResource @testParams;
+                
+                $result -is [System.Boolean] | Should Be $true;
+            }
+            
+            It 'Passes when all parameters are correct' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                
+                $result = Test-TargetResource @testParams;
+                
+                $result | Should Be $true;
+            }
+            
+            It 'Passes when optional "LeaseDuration" parameter is correct' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                
+                $result = Test-TargetResource @testParams -LeaseDuration $testLeaseDuration.ToString();
+                
+                $result | Should Be $true;
+            }
+            
+            It 'Passes when optional "State" parameter is correct' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                
+                $result = Test-TargetResource @testParams -State 'Active';
+                
+                $result | Should Be $true;
+            }
+            
+            It 'Passes when "Ensure" = "Absent" and scope does not exist' {
+                Mock Get-DhcpServerv4Scope { }
+                
+                $result = Test-TargetResource @testParams -Ensure 'Absent';
+                
+                $result | Should Be $true;
+            }
+            
+            It 'Fails when "Name" parameter is incorrect' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                $testNameParams = $testParams.Clone();
+                $testNameParams['Name'] = 'IncorrectName';
+                
+                $result = Test-TargetResource @testNameParams;
+                
+                $result | Should Be $false;
+            }
+            
+            It 'Fails when "IPStartRange" parameter is incorrect' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                $testIPStartRangeParams = $testParams.Clone();
+                $testIPStartRangeParams['IPStartRange'] = '192.168.1.1';
+                
+                $result = Test-TargetResource @testIPStartRangeParams;
+                
+                $result | Should Be $false;
+            }
+            
+            It 'Fails when "IPEndRange" parameter is incorrect' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                $testIPEndRangeParams = $testParams.Clone();
+                $testIPEndRangeParams['IPEndRange'] = '192.168.1.254';
+                
+                $result = Test-TargetResource @testIPEndRangeParams;
+                
+                $result | Should Be $false;
+            }
+            
+            It 'Fails when "SubnetMask" parameter is incorrect' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                $testSubnetMaskParams = $testParams.Clone();
+                $testSubnetMaskParams['SubnetMask'] = '255.255.240.0';
+                
+                $result = Test-TargetResource @testSubnetMaskParams;
+                
+                $result | Should Be $false;
+            }
+            
+            It 'Fails when optional "LeaseDuration" parameter is incorrect' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                
+                $result = Test-TargetResource @testParams -LeaseDuration '08:00:00';
+                
+                $result | Should Be $false;
+            }
+            
+            It 'Fails when optional "State" parameter is incorrect' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                
+                $result = Test-TargetResource @testParams -State 'Inactive';
+                
+                $result | Should Be $false;
+            }
+            
+            It 'Fails when "Ensure" = "Absent" and scope does exist' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                
+                $result = Test-TargetResource @testParams -Ensure 'Absent';
+                
+                $result | Should Be $false;
+            }
+                       
+        }
+        #endregion
+
+        #region Function Set-TargetResource
+        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
+            
+            Mock Assert-Module -ParameterFilter { $ModuleName -eq 'DHCPServer' } { }
+            
+            It 'Calls "Add-DhcpServerv4Scope" when "Ensure" = "Present" and scope does not exist' {
+                Mock Get-DhcpServerv4Scope { }
+                Mock Add-DhcpServerv4Scope { }
+                
+                Set-TargetResource @testParams;
+                
+                Assert-MockCalled Add-DhcpServerv4Scope -Scope It;
+            }
+            
+            It 'Calls "Remove-DhcpServerv4Scope" when "Ensure" = "Absent" and scope does exist' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                Mock Remove-DhcpServerv4Scope { }
+                
+                Set-TargetResource @testParams -Ensure 'Absent';
+                
+                Assert-MockCalled Remove-DhcpServerv4Scope -Scope It;
+            }
+            
+            It 'Calls "Set-DhcpServerv4Scope" when "Ensure" = "Present" and scope does exist' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                Mock Set-DhcpServerv4Scope { }
+                
+                Set-TargetResource @testParams -LeaseDuration '08:00:00';
+                
+                Assert-MockCalled Set-DhcpServerv4Scope -Scope It;
+            }
+            
+            It 'Calls "Remove-DhcpServerv4Scope" when "Ensure" = "Present", scope does exist but "SubnetMask" is incorrect' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                Mock Remove-DhcpServerv4Scope { }
+                Mock Set-DhcpServerv4Scope { }
+                $testSubnetMaskParams = $testParams.Clone();
+                $testSubnetMaskParams['SubnetMask'] = '255.255.240.0';
+                
+                Set-TargetResource @testSubnetMaskParams;
+                
+                Assert-MockCalled Remove-DhcpServerv4Scope -Scope It;
+            }
+            
+        }
+        #endregion
+
+        #region Function Set-TargetResource
+        Describe "$($Global:DSCResourceName)\Validate-ResourceProperties" {
+            # TODO: Complete Tests...
+        }
+        #endregion
+
+    }
+    #endregion
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+
+    # TODO: Other Optional Cleanup Code Goes Here...
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,9 @@ install:
   - cd DscResource.Tests
   - ps: Import-Module .\TestHelper.psm1 -force
   - ps: Pop-Location
-
+  - ps: |
+      Add-WindowsFeature RSAT-DHCP
+  
 #---------------------------------# 
 #      build configuration        # 
 #---------------------------------# 


### PR DESCRIPTION
* Fixes #9
 * Adds test coverage for xDhcpServerScope
* Fixes #14
 * Changes comparisons to use the OptionIds rather than names which are localized
* Fixes #21
 * Updates readme, giving LeaseDuration examples
* Implements unit test template
 * Add-WindowsFeature RSAT-DHCP role installation into appveyor.yml

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdhcpserver/22)
<!-- Reviewable:end -->
