### PR TITLE
Adds Router property to output - Fixes #29

### DIFF
--- a/DSCResources/MSFT_xDhcpServerOption/MSFT_xDhcpServerOption.psm1
+++ b/DSCResources/MSFT_xDhcpServerOption/MSFT_xDhcpServerOption.psm1
@@ -66,6 +66,7 @@ function Get-TargetResource
             $dnsDomain = (($dhcpOption | Where-Object Name -like 'DNS Domain Name').value)[0]
             $ensure = 'Present'
             $dnsServerIP = ($dhcpOption | Where-Object Name -like 'DNS Servers').value
+            $Router = ($dhcpOption | Where-Object OptionId -Like 3).value
         }
     }
     catch
@@ -78,6 +79,7 @@ function Get-TargetResource
         AddressFamily = 'IPv4'
         Ensure = $ensure
         DnsServerIPAddress = $dnsServerIP
+        Router = $Router
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 * Converted AppVeyor.yml to pull Pester from PSGallery instead of Chocolatey
+* Bug Fix fixes xDhcpServerOption\Get-TargetResource not returning Router property
 
 ### 1.4.0.0
 

--- a/Tests/Unit/MSFT_xDhcpServerOption.tests.ps1
+++ b/Tests/Unit/MSFT_xDhcpServerOption.tests.ps1
@@ -29,6 +29,48 @@ try
         # TODO: Optopnal Load Mock for use in Pester tests here...
         #endregion
 
+        $testScopeID = '192.168.1.0';
+        $testDnsServerIPAddress = '192.168.1.10';
+        $testDnsDomain = 'contoso.com';
+        $testRouter = '192.168.1.1';
+        
+        $testParams = @{
+            ScopeID = $testScopeID;
+            DnsServerIPAddress = $testDnsServerIPAddress;
+        }
+                
+        $fakeDhcpServerv4Option = [PSCustomObject] @{
+            ScopeID = $testScopeID;
+            DnsDomain = $testDnsDomain;
+            AddressFamily = 'IPv4';
+            DnsServerIPAddress = $testDnsServerIPAddress;
+            Router = $testRouter;
+        }
+
+        $fakeDhcpServerv4Scope = [PSCustomObject] @{
+            ScopeID = $testScopeID;
+        }
+
+        #region Function Get-TargetResource
+        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+
+            It 'Returns all properties' {
+                Mock Get-DhcpServerv4Scope { return $fakeDhcpServerv4Scope; }
+                Mock Get-DhcpServerv4OptionValue { return $fakeDhcpServerv4Option }
+                $result = Get-TargetResource @testParams;
+                
+                $missingCount = 
+                (
+                    $fakeDhcpServerv4Option.psobject.properties.ForEach{
+                        $result.ContainsKey($_.Name)
+                    } | Where-Object { -not $_ } | Measure-Object
+                ).Count
+
+                $missingCount | Should Be 0;
+            }
+        }
+        #endregion Function Get-TargetResource
+
         #region Function ValidateResourceProperties
         Describe "$($Global:DSCResourceName)\ValidateResourceProperties" {
     


### PR DESCRIPTION
- Adds Pester Test for xDhcpServerOption\Get-TargetResource output
- Fixes #29 : Adds Router property to output

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdhcpserver/30)
<!-- Reviewable:end -->
