### PR TITLE
Added Router to resource description in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **DnsServerIPAddress**: IP address of DNS Servers
 * **DnsDomain**: Domain name of DNS Server
 * **AddressFamily**: Address family type
+* **Router**: The default gateway for clients
 * **Ensure**: Whether option should be set or removed
 
 ### xDhcpServerAuthorization


### PR DESCRIPTION
Added Router to the list of DSC Resources in the Readme, was not listed previously, and if one were to run a configuration without this option, it will fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdhcpserver/42)
<!-- Reviewable:end -->
