### PR TITLE
xDhcpServer: Added default AppVeyor template and status badges

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,24 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+comment:
+  layout: "reach, diff"
+  behavior: default
+
+coverage:
+  range: 50..80
+  round: down
+  precision: 0
+
+  status:
+    project:
+      default:
+        # Set the overall project code coverage requirement to 70%
+        target: 70
+    patch:
+      default:
+        # Set the pull request requirement to not regress overall coverage by more than 5%
+        # and let codecov.io set the goal for the code changed in the patch.
+        target: auto
+        threshold: 5

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Microsoft Corporation.
+Copyright (c) 2018 Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-[![Build status](https://ci.appveyor.com/api/projects/status/uan12tf7tfxhg7m5/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xdhcpserver/branch/master)
-
 # xDhcpServer
 
 The **xDhcpServer** DSC resources are used for configuring and managing a DHCP server. They include **xDhcpServerScope**, **xDhcpServerReservation**, **xDhcpServerOptions** and **xDhcpServerAuthorization**.
@@ -7,9 +5,29 @@ The **xDhcpServer** DSC resources are used for configuring and managing a DHCP s
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
 
-## Contributing
-Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
+## Branches
 
+### master
+
+[![Build status](https://ci.appveyor.com/api/projects/status/uan12tf7tfxhg7m5/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xDhcpServer/branch/master)
+[![codecov](https://codecov.io/gh/PowerShell/xDhcpServer/branch/master/graph/badge.svg)](https://codecov.io/gh/PowerShell/xDhcpServer/branch/master)
+
+This is the branch containing the latest release -
+no contributions should be made directly to this branch.
+
+### dev
+
+[![Build status](https://ci.appveyor.com/api/projects/status/uan12tf7tfxhg7m5/branch/dev?svg=true)](https://ci.appveyor.com/project/PowerShell/xDhcpServer/branch/dev)
+[![codecov](https://codecov.io/gh/PowerShell/xDhcpServer/branch/dev/graph/badge.svg)](https://codecov.io/gh/PowerShell/xDhcpServer/branch/dev)
+
+This is the development branch
+to which contributions should be proposed by contributors as pull requests.
+This development branch will periodically be merged to the master branch,
+and be released to [PowerShell Gallery](https://www.powershellgallery.com/).
+
+## Contributing
+
+Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
 
 ## Resources
 
@@ -58,16 +76,16 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **IPAddress**: IP v4 address of the server to authorized. If not specified, it default to the first IPv4 address of the enacting node.
 
 ### xDhcpServerClass
-        
+
  * **Name**: DHCP Class Name.
  * **Type**: Class type, should be Vendor or User.
  * **AsciiData**: Class Data in a ascii formated string.
  * **AddressFamily**: Currently should be "IPv4".
  * **Description**: Class Description.
  * **Ensure**: Whether class should be set or removed.
- 
+
  ### xDhcpServerOptionDefinition
- 
+
  *  **OptionID**: Option ID, should be a number between 1 and 255.
  *  **VendorClass**: Vendor class. Use an empty string for standard option class.
  *  **Name**: Option name.
@@ -81,6 +99,11 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleased
 
+* Changes to xDhcpServer
+  * Updated year in LICENSE file.
+  * Updated year in module manifest.
+  * Added Codecov and status badges to README.md.
+  * Update appveyor.yml to use the default template.
 * Added xDhcpServerOptionDefinition
 
 ### 1.6.0.0
@@ -215,7 +238,7 @@ configuration Sample_DHCPServerClass
         Type = 'Vendor'
         AsciiData = 'sampledata'
         AddressFamily = 'IPv4'
-        Description = 'Vendor Class Description' 
+        Description = 'Vendor Class Description'
     }
 }
 ```

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,15 +3,12 @@
 #---------------------------------#
 version: 1.5.{build}.0
 install:
-  - git clone https://github.com/PowerShell/DscResource.Tests
-  - ps: |
-        Push-Location
-        cd DscResource.Tests
-        Import-Module .\TestHelper.psm1 -force
-        Pop-Location
-        Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
-        Install-Module -Name Pester -Repository PSGallery -Force
-        Add-WindowsFeature RSAT-DHCP
+    - git clone https://github.com/PowerShell/DscResource.Tests
+    - ps: Write-Verbose -Message "PowerShell version $($PSVersionTable.PSVersion)" -Verbose
+    - ps: Import-Module "$env:APPVEYOR_BUILD_FOLDER\DscResource.Tests\AppVeyor.psm1"
+    - ps: Invoke-AppveyorInstallTask
+    - ps: Add-WindowsFeature RSAT-DHCP
+
 #---------------------------------#
 #      build configuration        #
 #---------------------------------#
@@ -24,12 +21,7 @@ build: false
 
 test_script:
     - ps: |
-        $testResultsFile = ".\TestsResults.xml"
-        $res = Invoke-Pester -OutputFormat NUnitXml -OutputFile $testResultsFile -PassThru
-        (New-Object 'System.Net.WebClient').UploadFile("https://ci.appveyor.com/api/testresults/nunit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path $testResultsFile))
-        if ($res.FailedCount -gt 0) {
-            throw "$($res.FailedCount) tests failed."
-        }
+        Invoke-AppveyorTestScriptTask -CodeCoverage -CodeCovIo -ExcludeTag @()
 
 #---------------------------------#
 #      deployment configuration   #
@@ -37,30 +29,5 @@ test_script:
 
 # scripts to run before deployment
 deploy_script:
-  - ps: |
-      # Creating project artifact
-      $stagingDirectory = (Resolve-Path ..).Path
-      $manifest = Join-Path $pwd "xDhcpServer.psd1"
-      (Get-Content $manifest -Raw).Replace("1.5.0.0", $env:APPVEYOR_BUILD_VERSION) | Out-File $manifest
-      $zipFilePath = Join-Path $stagingDirectory "$(Split-Path $pwd -Leaf).zip"
-      Add-Type -assemblyname System.IO.Compression.FileSystem
-      [System.IO.Compression.ZipFile]::CreateFromDirectory($pwd, $zipFilePath)
-
-      # Creating NuGet package artifact
-      New-Nuspec -packageName $env:APPVEYOR_PROJECT_NAME -version $env:APPVEYOR_BUILD_VERSION -author "Microsoft" -owners "Microsoft" -licenseUrl "https://github.com/PowerShell/DscResources/blob/master/LICENSE" -projectUrl "https://github.com/$($env:APPVEYOR_REPO_NAME)" -packageDescription $env:APPVEYOR_PROJECT_NAME -tags "DesiredStateConfiguration DSC DSCResourceKit" -destinationPath .
-      nuget pack ".\$($env:APPVEYOR_PROJECT_NAME).nuspec" -outputdirectory .
-      $nuGetPackageName = $env:APPVEYOR_PROJECT_NAME + "." + $env:APPVEYOR_BUILD_VERSION + ".nupkg"
-      $nuGetPackagePath = (Get-ChildItem $nuGetPackageName).FullName
-
-      @(
-          # You can add other artifacts here
-          $zipFilePath,
-          $nuGetPackagePath
-      ) | % {
-          Write-Host "Pushing package $_ as Appveyor artifact"
-          Push-AppveyorArtifact $_
-        }
-
-
-
-
+    - ps: |
+        Invoke-AppveyorAfterTestTask

--- a/xDhcpServer.psd1
+++ b/xDhcpServer.psd1
@@ -12,7 +12,7 @@ Author = 'Microsoft Corporation'
 CompanyName = 'Microsoft Corporation'
 
 # Copyright statement for this module
-Copyright = '(c) 2014 Microsoft Corporation. All rights reserved.'
+Copyright = '(c) 2018 Microsoft Corporation. All rights reserved.'
 
 # Description of the functionality provided by this module
 Description = 'Module with DSC Resources for DHCP Server area'


### PR DESCRIPTION
- Changes to xDhcpServer
  - Updated year in LICENSE file.
  - Updated year in module manifest.
  - Added Codecov and status badges to README.md.
  - Update appveyor.yml to use the default template.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xdhcpserver/44)
<!-- Reviewable:end -->
